### PR TITLE
Add email as a claim

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -295,10 +295,14 @@ async fn sign(
     }
     let short_name = claims.short_name;
 
-    let principals: Vec<String> = projects
+    let mut principals: Vec<String> = projects
         .keys()
         .map(|p| format!("{short_name}.{}", p.0))
         .collect();
+    if !claims.email.is_empty() {
+        // TODO: make this opt in via config
+        principals.push(claims.email.clone());
+    };
     if principals.is_empty() {
         error!(
             "No valid principals from: user_projects={:?}, config_platforms={:?}",


### PR DESCRIPTION
For cases where keycloak doesn't need to talk to waldur to get the list of projects, and instead look at making the Waldur agent write / populate the user email into a AuthorizedPrincipalsFile or Command instead.